### PR TITLE
feat(storage): migrate from localStorage to chrome.storage.local

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,7 @@
     "128": "icon-128.png"
   },
   "permissions": [
+    "storage",
     "activeTab",
     "sidePanel"
   ],

--- a/src/pages/panel/Panel.tsx
+++ b/src/pages/panel/Panel.tsx
@@ -15,11 +15,13 @@ export default function Panel() {
   });
 
   useEffect(() => {
-    const storedData: string | null = localStorage.getItem(keyname);
-    if (storedData) {
-      const parsed: PanelFormValues = JSON.parse(storedData) as PanelFormValues;
-      setFormValues(parsed);
-    }
+    // save form values to chrome local storage
+    chrome.storage.local.get(keyname).then((data) => {
+      if (data[keyname]) {
+        const parsed: PanelFormValues = data[keyname] as PanelFormValues;
+        setFormValues(parsed);
+      }
+    });
   }, []);
 
   const onChange: InputChangeHandler = (e) => {
@@ -30,8 +32,8 @@ export default function Panel() {
   const handleSubmit: SubmitHandler = (e) => {
     e.preventDefault();
     model.current?.showModal();
-    // Save the form values to local storage
-    localStorage.setItem(keyname, JSON.stringify(formValues));
+    // read form values from state
+    chrome.storage.local.set({ [keyname]: formValues });
   };
 
   return (


### PR DESCRIPTION
Switch from using localStorage to chrome.storage.local to better align with Chrome extension storage practices. This change ensures data persistence across sessions and improves compatibility with the extension's permissions.