### PR TITLE
refactor(job-fetcher): remove goToFooter and make methods async

### DIFF
--- a/src/jobfetcher/jobfetcher.ts
+++ b/src/jobfetcher/jobfetcher.ts
@@ -22,8 +22,6 @@ export default abstract class JobFetcher {
 
       while (true) {
         await slowDelay();
-        await this.goToFooter();
-        await slowDelay();
         const count = await this.getJDCountOnCurPage();
 
         for (let i = 1; i <= count; i++) {
@@ -108,14 +106,6 @@ export default abstract class JobFetcher {
     if (this.tabId === undefined) throw new Error("Tab ID is null");
     return await chrome.tabs.sendMessage(this.tabId, {
       action: "nextPage",
-      platform: this.platform,
-    });
-  }
-
-  async goToFooter(): Promise<void> {
-    if (this.tabId === undefined) throw new Error("Tab ID is null");
-    await chrome.tabs.sendMessage(this.tabId, {
-      action: "goToFooter",
       platform: this.platform,
     });
   }

--- a/src/pages/content/index.ts
+++ b/src/pages/content/index.ts
@@ -10,22 +10,26 @@ const mapping: { [key: string]: Operator } = {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.platform && mapping[message.platform]) {
     const operator = mapping[message.platform];
-    switch (message.action) {
-      case "getJDCountOnCurPage":
-        sendResponse(operator.getJDCountOnCurPage());
-        break;
-      case "nextPage":
-        sendResponse(operator.nextPage());
-        break;
-      case "clickJD":
-        operator.clickJD(message.id);
-        break;
-      case "fetchJDInfo":
-        sendResponse(operator.fetchJDInfo());
-        break;
-      case "goToFooter":
-        operator.goToFooter();
-        break;
-    }
+
+    const handleAsync = async () => {
+      switch (message.action) {
+        case "getJDCountOnCurPage":
+          sendResponse(await operator.getJDCountOnCurPage());
+          break;
+        case "nextPage":
+          sendResponse(await operator.nextPage());
+          break;
+        case "clickJD":
+          await operator.clickJD(message.id);
+          sendResponse(true);
+          break;
+        case "fetchJDInfo":
+          sendResponse(await operator.fetchJDInfo());
+          break;
+      }
+    };
+
+    handleAsync();
+    return true; // keep the channel until sendResponse is called
   }
 });

--- a/src/pages/content/linkedin.ts
+++ b/src/pages/content/linkedin.ts
@@ -1,12 +1,17 @@
 import Operator from "./operator";
 
 export default class Linkedin extends Operator {
-  getJDCountOnCurPage(): number {
+  async getJDCountOnCurPage(): Promise<number> {
     if (this.isNoMatch()) return 0;
+
+    const list = document.querySelector(
+      ".scaffold-layout__list > div"
+    ) as HTMLElement;
+    await this.scrollTo(list, 10, 10);
     return document.querySelectorAll('div[data-view-name="job-card"]').length;
   }
 
-  nextPage(): boolean {
+  async nextPage(): Promise<boolean> {
     if (this.isNoMatch()) return false;
     const nextPageButton = document.querySelector(
       ".jobs-search-pagination__button--next"
@@ -18,7 +23,7 @@ export default class Linkedin extends Operator {
     return false;
   }
 
-  clickJD(id: number): void {
+  async clickJD(id: number) {
     const jobList = document.querySelectorAll(
       'div[data-view-name="job-card"]'
     ) as NodeListOf<HTMLDivElement>;
@@ -29,7 +34,7 @@ export default class Linkedin extends Operator {
     }
   }
 
-  fetchJDInfo(): JDInfo {
+  async fetchJDInfo(): Promise<JDInfo> {
     const title = document.querySelector(
       ".job-details-jobs-unified-top-card__job-title a"
     ) as HTMLAnchorElement;
@@ -59,12 +64,5 @@ export default class Linkedin extends Operator {
   // if no match, linkedin will still show recommened jobs, so we need to check if the banner is shown
   isNoMatch(): boolean {
     return document.querySelector(".jobs-search-no-results-banner") !== null;
-  }
-
-  goToFooter(): void {
-    const footer = document.querySelector(
-      "#jobs-search-results-footer"
-    ) as HTMLDivElement;
-    footer.scrollIntoView({ behavior: "smooth" });
   }
 }

--- a/src/pages/content/operator.ts
+++ b/src/pages/content/operator.ts
@@ -1,7 +1,14 @@
 export default abstract class Operator {
-  abstract getJDCountOnCurPage(): number;
-  abstract nextPage(): boolean;
-  abstract clickJD(id: number): void;
-  abstract fetchJDInfo(): JDInfo;
-  goToFooter(){}
+  abstract getJDCountOnCurPage(): Promise<number>;
+  abstract nextPage(): Promise<boolean>;
+  abstract clickJD(id: number): Promise<void>;
+  abstract fetchJDInfo(): Promise<JDInfo>;
+  
+  async scrollTo(scrollable: HTMLElement, step: number, interval: number) {
+    const scrollHeight = scrollable.scrollHeight;
+    for (let i = 0; i < scrollHeight; i += step) {
+      scrollable.scrollTop = i;
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
 }

--- a/src/pages/content/seek.ts
+++ b/src/pages/content/seek.ts
@@ -1,7 +1,7 @@
 import Operator from "./operator";
 
 export default class Seek extends Operator {
-  fetchJDInfo(): JDInfo {
+  async fetchJDInfo(): Promise<JDInfo> {
     const title = document.querySelector(
       'h1[data-automation="job-detail-title"] a'
     ) as HTMLAnchorElement;
@@ -30,11 +30,11 @@ export default class Seek extends Operator {
     return jdInfo;
   }
 
-  getJDCountOnCurPage(): number {
+  async getJDCountOnCurPage(): Promise<number> {
     return document.querySelectorAll('[data-card-type="JobCard"]').length;
   }
 
-  nextPage(): boolean {
+  async nextPage(): Promise<boolean> {
     const nextPageButton = document.querySelector(
       'a[aria-label="Next"][aria-hidden="false"]'
     ) as HTMLAnchorElement;
@@ -45,11 +45,11 @@ export default class Seek extends Operator {
     return false;
   }
 
-  clickJD(id: number) {
+  async clickJD(id: number) {
     const jobCard = document.querySelector(`#jobcard-${id}`) as HTMLElement;
     if (jobCard) {
       jobCard.click();
-    }else {
+    } else {
       throw new Error("Job card not found");
     }
   }


### PR DESCRIPTION
Convert operator methods to async and remove unnecessary goToFooter functionality Add scrollTo helper method for better job listing discovery Update message handler to properly handle async operations